### PR TITLE
Fix return value of poll_host_device

### DIFF
--- a/daemon/core.c
+++ b/daemon/core.c
@@ -94,7 +94,7 @@ static int poll_host_device(struct daemon_state *state) {
 wire_error:
 	if (buf)
 		buf_free(buf);
-	return 0;
+	return result;
 }
 
 void host_device_ready(struct ev_loop *loop, ev_io *handle, int revents) {


### PR DESCRIPTION
When receiving frames and no further frames are available, read() returns
EAGAIN. In the previous implementation, frames would not be processed until
the circular multicast buffer is full, resulting in a periodic burst of
packets. In general, a receive failure should not affect processing of packets
that were already successfully received.

Tested on:
- TP-Link Archer T1U V1.0 (mt76)
- Alfa AWUS036NHA (ath9k_htc)